### PR TITLE
Fix missing await in findOne methods

### DIFF
--- a/src/langages/langages.service.ts
+++ b/src/langages/langages.service.ts
@@ -193,8 +193,8 @@ export class LangagesService {
     return this.langageModel.find().skip(offset).limit(limit).exec();
   }
 
-  findOne(id: string) {
-    const langage = this.langageModel.findOne({ _id: id }).exec();
+  async findOne(id: string) {
+    const langage = await this.langageModel.findOne({ _id: id }).exec();
     if (!langage) {
       throw new NotFoundException(`Langage with id ${id} not found`);
     }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -21,8 +21,8 @@ export class NewsService {
     return this.newsModel.find().skip(offset).limit(limit).exec();
   }
 
-  findOne(id: string) {
-    const news = this.newsModel.findOne({ _id: id }).exec();
+  async findOne(id: string) {
+    const news = await this.newsModel.findOne({ _id: id }).exec();
     if (!news) {
       throw new NotFoundException(`Langage with id ${id} not found`);
     }


### PR DESCRIPTION
## Summary
- fix asynchronous `findOne` methods so they correctly await database calls

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841ba8a2634832d90d47c1b1db76266