### PR TITLE
Add bcrypt service tests

### DIFF
--- a/src/iam/hashing/bcrypt.service.spec.ts
+++ b/src/iam/hashing/bcrypt.service.spec.ts
@@ -15,4 +15,17 @@ describe('BcryptService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('hash() returns a string different from the input', async () => {
+    const password = 'test';
+    const hashed = await service.hash(password);
+    expect(typeof hashed).toBe('string');
+    expect(hashed).not.toEqual(password);
+  });
+
+  it('compare() successfully matches a hashed value', async () => {
+    const password = 'secret';
+    const hashed = await service.hash(password);
+    await expect(service.compare(password, hashed)).resolves.toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- extend bcrypt service unit test coverage

## Testing
- `npx jest src/iam/hashing/bcrypt.service.spec.ts`
- `npm run test` *(fails: Nest can't resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c0ada1ac832da4b4c7f33323f7d1