### PR TITLE
Add missing popular languages

### DIFF
--- a/src/langages/langage-sync.config.ts
+++ b/src/langages/langage-sync.config.ts
@@ -36,7 +36,7 @@ export const SYNC_LANGAGES: LangageSyncConfig[] =  [
   {
   nameInDb: 'Node.js',
   sourceType: 'custom',
-  sourceUrl: 'https://nodejs.org/dist/index.json',
+  sourceUrl: 'nodejs',
   ltsSupport: true,
   },
   {
@@ -89,9 +89,10 @@ export const SYNC_LANGAGES: LangageSyncConfig[] =  [
   },
   {
   nameInDb: 'Python',
-  sourceType: 'custom',
-  sourceUrl: 'https://www.python.org/doc/versions/',
+  sourceType: 'github',
+  sourceUrl: 'python/cpython',
   ltsSupport: true,
+  useTags: true,
   },
   {
   nameInDb: 'Go',
@@ -175,6 +176,42 @@ export const SYNC_LANGAGES: LangageSyncConfig[] =  [
   nameInDb: 'Ansible',
   sourceType: 'github',
   sourceUrl: 'ansible/ansible',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Swift',
+  sourceType: 'github',
+  sourceUrl: 'apple/swift',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Kotlin',
+  sourceType: 'github',
+  sourceUrl: 'JetBrains/kotlin',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Ruby',
+  sourceType: 'github',
+  sourceUrl: 'ruby/ruby',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'C#',
+  sourceType: 'github',
+  sourceUrl: 'dotnet/runtime',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'C++',
+  sourceType: 'github',
+  sourceUrl: 'cplusplus/draft',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Scala',
+  sourceType: 'github',
+  sourceUrl: 'scala/scala',
   ltsSupport: false,
   },
   ];

--- a/src/langages/langage-update.service.ts
+++ b/src/langages/langage-update.service.ts
@@ -134,6 +134,26 @@ export class LangageUpdateService {
   
     this.logger.log(`✅ Kotlin synchronisé : ${latest}`);
   }
+
+  // SYNCRO RUBY
+  async updateRuby() {
+    await this.updateFromGitHubRelease('Ruby', 'ruby/ruby');
+  }
+
+  // SYNCRO C#
+  async updateCSharp() {
+    await this.updateFromGitHubRelease('C#', 'dotnet/runtime');
+  }
+
+  // SYNCRO C++
+  async updateCpp() {
+    await this.updateFromGitHubRelease('C++', 'cplusplus/draft');
+  }
+
+  // SYNCRO SCALA
+  async updateScala() {
+    await this.updateFromGitHubRelease('Scala', 'scala/scala');
+  }
   
 
   private githubHeaders(): Record<string, string> {
@@ -240,7 +260,7 @@ export class LangageUpdateService {
 
 
   async updateCustom(nameInDb: string, url: string) {
-    if (url === 'nodejs') {
+    if (url === 'nodejs' || url.includes('nodejs.org')) {
       const res = await firstValueFrom(this.http.get('https://nodejs.org/dist/index.json'));
       const lts = res.data.find((r: any) => r.lts);
       const current = res.data.find((r: any) => !r.lts);


### PR DESCRIPTION
## Summary
- add widely used languages to `SYNC_LANGAGES`
- add simple update wrappers for Ruby, C#, C++, and Scala
- improve Node.js custom update detection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d5c71120832d90809c8010036ab8