### PR TITLE
Add service unit tests

### DIFF
--- a/src/iam/authentication/authentication.service.spec.ts
+++ b/src/iam/authentication/authentication.service.spec.ts
@@ -1,18 +1,68 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { JwtService } from '@nestjs/jwt';
+import { BadRequestException } from '@nestjs/common';
 import { AuthenticationService } from './authentication.service';
+import { UsersService } from '../../users/users.service';
+import { HashingService } from '../hashing/hashing.service';
+import { RefreshTokenIdsStorage } from './refresh-token-ids.storage/refresh-token-ids.storage';
+import { MailService } from '../../mail.service';
+import jwtConfig from '../config/jwt.config';
 
-describe.skip('AuthenticationService', () => {
+jest.mock('bcrypt', () => ({ compare: jest.fn() }));
+import * as bcrypt from 'bcrypt';
+
+describe('AuthenticationService', () => {
   let service: AuthenticationService;
+  const userModel = { findOne: jest.fn(), findById: jest.fn() } as any;
+  const usersService = { findByEmail: jest.fn() } as any;
+  const hashingService = { compare: jest.fn(), hash: jest.fn() } as any;
+  const jwtService = { signAsync: jest.fn(), verifyAsync: jest.fn() } as any;
+  const refreshTokenIdsStorage = { insert: jest.fn(), validate: jest.fn(), invalidate: jest.fn() } as any;
+  const mailService = { sendConfirmationEmail: jest.fn(), sendReinitialisationMail: jest.fn() } as any;
+  const config = { secret: 's', audience: 'a', issuer: 'i', accessTokenTtl: 3600, refreshTokenTtl: 7200 };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthenticationService],
+      providers: [
+        AuthenticationService,
+        { provide: getModelToken('User'), useValue: userModel },
+        { provide: HashingService, useValue: hashingService },
+        { provide: JwtService, useValue: jwtService },
+        { provide: jwtConfig.KEY, useValue: config },
+        { provide: UsersService, useValue: usersService },
+        { provide: RefreshTokenIdsStorage, useValue: refreshTokenIdsStorage },
+        { provide: MailService, useValue: mailService },
+      ],
     }).compile();
 
     service = module.get<AuthenticationService>(AuthenticationService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('validateUser', () => {
+    it('returns user when credentials are valid', async () => {
+      const user = { email: 'test@example.com', password: 'hash' } as any;
+      usersService.findByEmail.mockResolvedValue(user);
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.validateUser('test@example.com', 'pwd');
+
+      expect(result).toBe(user);
+      expect(usersService.findByEmail).toHaveBeenCalledWith('test@example.com');
+      expect(bcrypt.compare).toHaveBeenCalledWith('pwd', 'hash');
+    });
+
+    it('throws when credentials are invalid', async () => {
+      usersService.findByEmail.mockResolvedValue(null);
+      await expect(service.validateUser('x', 'y')).rejects.toBeInstanceOf(BadRequestException);
+    });
   });
 });

--- a/src/news/news.service.spec.ts
+++ b/src/news/news.service.spec.ts
@@ -1,18 +1,82 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken, getConnectionToken } from '@nestjs/mongoose';
 import { NewsService } from './news.service';
+import { News, Recommendation } from './entities/news.entity';
+import { EventEntity } from '../events/entities/event.entity/event.entity';
+import { NotFoundException, ConflictException } from '@nestjs/common';
 
-describe.skip('NewsService', () => {
+const MockNewsModel: any = jest.fn();
+MockNewsModel.findOne = jest.fn();
+MockNewsModel.findById = jest.fn();
+
+const MockRecommendationModel: any = jest.fn();
+const MockEventModel: any = jest.fn();
+
+describe('NewsService', () => {
   let service: NewsService;
+  let newsModel: typeof MockNewsModel;
+  let recommendationModel: typeof MockRecommendationModel;
+  let eventModel: typeof MockEventModel;
+  let connection: any;
 
   beforeEach(async () => {
+    newsModel = MockNewsModel as any;
+    recommendationModel = MockRecommendationModel as any;
+    eventModel = MockEventModel as any;
+    connection = {
+      startSession: jest.fn().mockResolvedValue({
+        startTransaction: jest.fn(),
+        commitTransaction: jest.fn(),
+        abortTransaction: jest.fn(),
+        endSession: jest.fn(),
+      }),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NewsService],
+      providers: [
+        NewsService,
+        { provide: getModelToken(News.name), useValue: newsModel },
+        { provide: getModelToken(Recommendation.name), useValue: recommendationModel },
+        { provide: getConnectionToken(), useValue: connection },
+        { provide: getModelToken(EventEntity.name), useValue: eventModel },
+      ],
     }).compile();
 
     service = module.get<NewsService>(NewsService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('findOne should throw when not found', async () => {
+    const exec = jest.fn().mockResolvedValue(null);
+    (newsModel.findOne as jest.Mock).mockReturnValue({ exec });
+
+    await expect(service.findOne('1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('incrementLikes should add like for new user', async () => {
+    const article = { likedBy: [], recommendations: 0, save: jest.fn().mockResolvedValue({}) } as any;
+    (newsModel.findById as jest.Mock).mockResolvedValue(article);
+
+    const result = await service.incrementLikes('a', 'user');
+
+    expect(newsModel.findById).toHaveBeenCalledWith('a');
+    expect(article.recommendations).toBe(1);
+    expect(article.likedBy).toContain('user');
+    expect(article.save).toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+
+  it('incrementLikes should throw when already liked', async () => {
+    const article = { likedBy: ['user'], recommendations: 1 } as any;
+    (newsModel.findById as jest.Mock).mockResolvedValue(article);
+
+    await expect(service.incrementLikes('a', 'user')).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,18 +1,54 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
 import { UsersService } from './users.service';
+import { User } from './entities/user.entity';
 
-describe.skip('UsersService', () => {
+const MockUserModel: any = jest.fn();
+MockUserModel.findOne = jest.fn();
+
+describe('UsersService', () => {
   let service: UsersService;
+  let userModel: typeof MockUserModel;
 
   beforeEach(async () => {
+    userModel = MockUserModel as any;
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        { provide: getModelToken(User.name), useValue: userModel },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('create should save a user', async () => {
+    const dto: any = { email: 'test@example.com' };
+    const save = jest.fn().mockResolvedValue({ _id: '1', ...dto });
+    userModel.mockImplementation(() => ({ save }));
+
+    const result = await service.create(dto);
+
+    expect(userModel).toHaveBeenCalledWith(dto);
+    expect(save).toHaveBeenCalled();
+    expect(result).toEqual({ _id: '1', ...dto });
+  });
+
+  it('findOne should return a user', async () => {
+    const exec = jest.fn().mockResolvedValue({ _id: '1' });
+    (userModel.findOne as jest.Mock).mockReturnValue({ exec });
+
+    const result = await service.findOne('1');
+
+    expect(userModel.findOne).toHaveBeenCalledWith({ _id: '1' });
+    expect(result).toEqual({ _id: '1' });
   });
 });


### PR DESCRIPTION
## Summary
- expand authentication service tests and unskip
- add unit tests for users service
- add unit tests for news service

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684def934034832dafe47f8ea41d2c1e