### PR TITLE
Improve NewsService unit tests

### DIFF
--- a/src/mailer-test.service.spec.ts
+++ b/src/mailer-test.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailerService } from '@nestjs-modules/mailer';
+import { MailerTestService } from './mailer-test.service';
+
+describe('MailerTestService', () => {
+  let service: MailerTestService;
+  const mailer = { sendMail: jest.fn() } as any;
+
+  beforeEach(async () => {
+    process.env.MAIL_FROM = 'from@example.com';
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MailerTestService,
+        { provide: MailerService, useValue: mailer },
+      ],
+    }).compile();
+
+    service = module.get<MailerTestService>(MailerTestService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return success when sending email succeeds', async () => {
+    mailer.sendMail.mockResolvedValue(undefined);
+
+    const result = await service.sendTestEmail('test@example.com');
+
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: 'test@example.com',
+      from: '"Verstack" <from@example.com>',
+      subject: '✅ Test d’envoi depuis NestJS via Brevo',
+      html: `<p>Si tu vois ce mail, c’est que tout fonctionne bien 🚀</p>`,
+    });
+    expect(result).toEqual({
+      success: true,
+      message: 'Email envoyé avec succès !',
+    });
+  });
+
+  it('should return failure when sendMail throws', async () => {
+    const error = new Error('boom');
+    mailer.sendMail.mockRejectedValue(error);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await service.sendTestEmail('fail@example.com');
+
+    expect(spy).toHaveBeenCalledWith('Erreur d’envoi :', error);
+    expect(result).toEqual({ success: false, message: 'boom' });
+
+    spy.mockRestore();
+  });
+});

--- a/src/news/news.service.spec.ts
+++ b/src/news/news.service.spec.ts
@@ -6,10 +6,14 @@ import { EventEntity } from '../events/entities/event.entity/event.entity';
 import { NotFoundException, ConflictException } from '@nestjs/common';
 
 const MockNewsModel: any = jest.fn();
+MockNewsModel.find = jest.fn();
 MockNewsModel.findOne = jest.fn();
+MockNewsModel.findOneAndUpdate = jest.fn();
+MockNewsModel.deleteOne = jest.fn();
 MockNewsModel.findById = jest.fn();
 
 const MockRecommendationModel: any = jest.fn();
+MockRecommendationModel.findOne = jest.fn();
 const MockEventModel: any = jest.fn();
 
 describe('NewsService', () => {
@@ -78,5 +82,131 @@ describe('NewsService', () => {
     (newsModel.findById as jest.Mock).mockResolvedValue(article);
 
     await expect(service.incrementLikes('a', 'user')).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('incrementLikes should throw when article not found', async () => {
+    (newsModel.findById as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.incrementLikes('x', 'u')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('findOne should return a news', async () => {
+    const exec = jest.fn().mockResolvedValue({ id: '1' });
+    (newsModel.findOne as jest.Mock).mockReturnValue({ exec });
+
+    const result = await service.findOne('1');
+
+    expect(newsModel.findOne).toHaveBeenCalledWith({ _id: '1' });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('findAll should query with pagination', async () => {
+    const exec = jest.fn().mockResolvedValue(['a']);
+    const limit = jest.fn().mockReturnValue({ exec });
+    const skip = jest.fn().mockReturnValue({ limit });
+    (newsModel.find as jest.Mock).mockReturnValue({ skip });
+
+    const result = await service.findAll({ limit: 1, offset: 2 });
+
+    expect(newsModel.find).toHaveBeenCalled();
+    expect(skip).toHaveBeenCalledWith(2);
+    expect(limit).toHaveBeenCalledWith(1);
+    expect(exec).toHaveBeenCalled();
+    expect(result).toEqual(['a']);
+  });
+
+  it('create should save a news', async () => {
+    const dto: any = { title: 't' };
+    const save = jest.fn().mockResolvedValue(dto);
+    newsModel.mockImplementation(() => ({ save }));
+
+    const result = await service.create(dto);
+
+    expect(save).toHaveBeenCalled();
+    expect(result).toEqual(dto);
+  });
+
+  it('update should return updated news', async () => {
+    const updated = { title: 'u' };
+    const exec = jest.fn().mockResolvedValue(updated);
+    (newsModel.findOneAndUpdate as jest.Mock).mockReturnValue({ exec });
+
+    const result = await service.update('1', { title: 'u' });
+
+    expect(newsModel.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: '1' },
+      { $set: { title: 'u' } },
+      { new: true },
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it('update should throw when news not found', async () => {
+    const exec = jest.fn().mockResolvedValue(null);
+    (newsModel.findOneAndUpdate as jest.Mock).mockReturnValue({ exec });
+    await expect(service.update('1', {})).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('remove should delete news', async () => {
+    const news = { _id: '1', save: jest.fn() };
+    const execFind = jest.fn().mockResolvedValue(news);
+    (newsModel.findOne as jest.Mock).mockReturnValue({ exec: execFind });
+    const execDelete = jest.fn().mockResolvedValue({ deleted: true });
+    (newsModel.deleteOne as jest.Mock).mockReturnValue({ exec: execDelete });
+
+    const result = await service.remove('1');
+
+    expect(execDelete).toHaveBeenCalled();
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it('remove should throw when news not found', async () => {
+    const exec = jest.fn().mockResolvedValue(null);
+    (newsModel.findOne as jest.Mock).mockReturnValue({ exec });
+
+    await expect(service.remove('1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('recommendNews should create event and recommendation', async () => {
+    const news = { _id: '1', recommendations: 0, save: jest.fn() } as any;
+    const eventSave = jest.fn();
+    eventModel.mockImplementation(() => ({ save: eventSave }));
+    const recSave = jest.fn();
+    recommendationModel.mockImplementation(() => ({ save: recSave }));
+    (recommendationModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue(null) });
+    const session = {
+      startTransaction: jest.fn(),
+      commitTransaction: jest.fn(),
+      abortTransaction: jest.fn(),
+      endSession: jest.fn(),
+    };
+    (connection.startSession as jest.Mock).mockResolvedValue(session);
+
+    await service.recommendNews(news, 'u');
+
+    expect(news.recommendations).toBe(1);
+    expect(eventSave).toHaveBeenCalledWith({ session });
+    expect(recSave).toHaveBeenCalledWith({ session });
+    expect(news.save).toHaveBeenCalledWith({ session });
+    expect(session.commitTransaction).toHaveBeenCalled();
+    expect(session.endSession).toHaveBeenCalled();
+  });
+
+  it('recommendNews should throw when already recommended', async () => {
+    const news = { _id: '1', recommendations: 0, save: jest.fn() } as any;
+    eventModel.mockImplementation(() => ({ save: jest.fn() }));
+    recommendationModel.mockImplementation(() => ({ save: jest.fn() }));
+    (recommendationModel.findOne as jest.Mock).mockReturnValue({ session: jest.fn().mockResolvedValue({}) });
+    const session = {
+      startTransaction: jest.fn(),
+      commitTransaction: jest.fn(),
+      abortTransaction: jest.fn(),
+      endSession: jest.fn(),
+    };
+    (connection.startSession as jest.Mock).mockResolvedValue(session);
+
+    await expect(service.recommendNews(news, 'u')).rejects.toBeInstanceOf(ConflictException);
+    expect(session.abortTransaction).toHaveBeenCalled();
+    expect(session.endSession).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extend mocked Mongoose model methods in `news.service.spec.ts`
- add tests covering findAll, findOne success, create, update, remove and recommend scenarios
- verify incrementLikes error paths

## Testing
- `npm run test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_684df1bf2608832dbbdd5874edcc155a