### PR TITLE
Add tests for GitHub tag parsing

### DIFF
--- a/src/langages/langage-sync.config.ts
+++ b/src/langages/langage-sync.config.ts
@@ -5,6 +5,8 @@ export interface LangageSyncConfig {
   sourceType: SyncSourceType;
   sourceUrl: string;
   ltsSupport?: boolean;
+  /** Prefix of the tag to identify the latest LTS version when using GitHub tags */
+  ltsTagPrefix?: string;
   useTags?: boolean; // For GitHub, use tags instead of releases
 }
 
@@ -298,6 +300,98 @@ export const SYNC_LANGAGES: LangageSyncConfig[] =  [
   nameInDb: 'Unity',
   sourceType: 'custom',
   sourceUrl: 'unity',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Express.js',
+  sourceType: 'npm',
+  sourceUrl: 'express',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Spring',
+  sourceType: 'github',
+  sourceUrl: 'spring-projects/spring-framework',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Django',
+  sourceType: 'github',
+  sourceUrl: 'django/django',
+  ltsSupport: true,
+  ltsTagPrefix: '4.2',
+  useTags: true,
+  },
+  {
+  nameInDb: 'JSON',
+  sourceType: 'custom',
+  sourceUrl: 'json',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Bash',
+  sourceType: 'github',
+  sourceUrl: 'bminor/bash',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'Erlang',
+  sourceType: 'github',
+  sourceUrl: 'erlang/otp',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Nim',
+  sourceType: 'github',
+  sourceUrl: 'nim-lang/Nim',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'V',
+  sourceType: 'github',
+  sourceUrl: 'vlang/v',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Web Assembly',
+  sourceType: 'github',
+  sourceUrl: 'WebAssembly/spec',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'SQL',
+  sourceType: 'custom',
+  sourceUrl: 'sql',
+  ltsSupport: false,
+  },
+  {
+  nameInDb: 'Haskell',
+  sourceType: 'github',
+  sourceUrl: 'ghc/ghc',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'Clojure',
+  sourceType: 'github',
+  sourceUrl: 'clojure/clojure',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'Flang',
+  sourceType: 'github',
+  sourceUrl: 'flang-compiler/flang',
+  ltsSupport: false,
+  useTags: true,
+  },
+  {
+  nameInDb: 'OCaml',
+  sourceType: 'github',
+  sourceUrl: 'ocaml/ocaml',
   ltsSupport: false,
   },
   ];

--- a/src/langages/langage-update.service.spec.ts
+++ b/src/langages/langage-update.service.spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { of } from 'rxjs';
+import { LangageUpdateService } from './langage-update.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { Langage } from './entities/langage.entity';
+
+describe('LangageUpdateService', () => {
+  let service: LangageUpdateService;
+  let http: { get: jest.Mock };
+  let model: { updateOne: jest.Mock };
+
+  beforeEach(async () => {
+    http = { get: jest.fn() } as any;
+    model = { updateOne: jest.fn().mockResolvedValue({}) } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LangageUpdateService,
+        { provide: HttpService, useValue: http },
+        { provide: getModelToken(Langage.name), useValue: model },
+      ],
+    }).compile();
+
+    service = module.get<LangageUpdateService>(LangageUpdateService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should ignore non version tags', async () => {
+    http.get
+      .mockReturnValueOnce(of({ data: [ { name: 'code-review/2009-07-22' }, { name: 'v5.1.0' } ] }))
+      .mockReturnValueOnce(of({ data: [] }));
+
+    await service.updateFromGitHubTag('Perl', 'Perl/perl5');
+
+    expect(model.updateOne).toHaveBeenCalledWith(
+      { name: 'Perl' },
+      expect.objectContaining({
+        $set: expect.objectContaining({ 'versions.$[v].label': '5.1.0' })
+      }),
+      { arrayFilters: [ { 'v.type': 'current' } ] }
+    );
+  });
+
+  it('should set lts when prefix provided', async () => {
+    http.get
+      .mockReturnValueOnce(of({ data: [ { name: 'v5.1.0' }, { name: 'v4.2.3' } ] }))
+      .mockReturnValueOnce(of({ data: [] }));
+
+    await service.updateFromGitHubTag('Django', 'django/django', '4.2');
+
+    expect(model.updateOne).toHaveBeenNthCalledWith(
+      1,
+      { name: 'Django' },
+      expect.objectContaining({
+        $set: expect.objectContaining({ 'versions.$[v].label': '5.1.0' })
+      }),
+      { arrayFilters: [ { 'v.type': 'current' } ] }
+    );
+    expect(model.updateOne).toHaveBeenNthCalledWith(
+      2,
+      { name: 'Django' },
+      expect.objectContaining({
+        $set: expect.objectContaining({ 'versions.$[v].label': '4.2.3' })
+      }),
+      { arrayFilters: [ { 'v.type': 'lts' } ] }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ignore tags without dotted numbers when parsing GitHub versions
- add unit tests for `updateFromGitHubTag`

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68568e3bdd14832d85a03b3a32ea4a1a