### PR TITLE
Refactor langage sync/update services

### DIFF
--- a/src/langages/custom-updaters.ts
+++ b/src/langages/custom-updaters.ts
@@ -1,0 +1,171 @@
+export interface CustomUpdaterDeps {
+  http: import('@nestjs/axios').HttpService;
+  setVersion: (name: string, type: string, label: string, releaseDate?: string) => Promise<void>;
+  logger: import('@nestjs/common').Logger;
+  normalizeLabel: (name: string, label: string) => string;
+}
+
+import { firstValueFrom } from 'rxjs';
+import * as semver from 'semver';
+import { LangageSyncConfig } from './langage-sync.config';
+
+export type CustomUpdater = (config: LangageSyncConfig, deps: CustomUpdaterDeps) => Promise<void>;
+
+export const CUSTOM_UPDATERS: Record<string, CustomUpdater> = {
+  Ruby: async (_config, { http, setVersion, logger }) => {
+    try {
+      const res = await firstValueFrom(
+        http.get('https://www.ruby-lang.org/en/downloads/', { responseType: 'text' as any })
+      );
+      const match = res.data.match(/Stable releases:[^]*?Ruby\s+(\d+\.\d+\.\d+)/i);
+      if (match?.[1]) {
+        await setVersion('Ruby', 'current', match[1]);
+        logger.log(`✅ Ruby (custom): current=${match[1]}`);
+      } else {
+        logger.warn(`⚠️ Ruby (custom): impossible de détecter la version`);
+      }
+    } catch (error) {
+      logger.error('❌ Erreur updateCustom [Ruby]:', error);
+    }
+  },
+  C: async (_config, { http, setVersion, logger }) => {
+    const res = await firstValueFrom(
+      http.get('https://en.wikipedia.org/wiki/C_(programming_language)', { responseType: 'text' as any })
+    );
+    const wiki = res.data as string;
+    const found: Array<{ version: string }> = [];
+    ['C23', 'C17', 'C11', 'C99'].forEach(ver => {
+      const regex = new RegExp(`${ver}.*?(?:ISO/IEC \\d+:\\d{4})`, 'i');
+      if (regex.test(wiki)) found.push({ version: ver });
+    });
+    if (found.length) {
+      for (const std of found) {
+        await setVersion('C', 'standard', std.version);
+      }
+      const current = found[0].version;
+      await setVersion('C', 'current', current);
+      logger.log(`📘 C (custom): standards=${found.map(f => f.version).join(', ')}, current=${current}`);
+    } else {
+      logger.warn('⚠️ C (custom): aucun standard détecté');
+    }
+  },
+  MATLAB: async (_config, { http, setVersion, logger }) => {
+    const res = await firstValueFrom(
+      http.get('https://www.mathworks.com/products/new_products/latest_features.html', { responseType: 'text' as any })
+    );
+    const match = res.data.match(/R(\d{4}[ab])/i);
+    if (match?.[1]) {
+      const raw = match[1];
+      const numeric = raw.slice(0, 4) + (raw.endsWith('a') ? '.1' : '.2');
+      await setVersion('MATLAB', 'current', numeric);
+      logger.log(`✅ MATLAB (custom): current=${numeric}`);
+    } else {
+      logger.warn(`⚠️ MATLAB (custom): impossible de détecter la version`);
+    }
+  },
+  R: async (_config, { http, setVersion, logger }) => {
+    try {
+      const res = await firstValueFrom(http.get('https://api.r-hub.io/rversions/r-release'));
+      const latest = res.data?.version;
+      const date = res.data?.date;
+      if (latest) {
+        await setVersion('R', 'current', latest, date);
+        logger.log(`✅ R (custom via r-hub): current=${latest}`);
+      } else {
+        logger.warn(`⚠️ R (custom): version introuvable`);
+      }
+    } catch (err) {
+      logger.error('❌ Erreur updateCustom [R]:', err);
+    }
+  },
+  Unity: async (_config, { http, setVersion, logger }) => {
+    try {
+      const res = await firstValueFrom(http.get('https://public-cdn.cloud.unity3d.com/hub/prod/releases-linux.json'));
+      const data = res.data;
+      const official = data.official;
+      const ltsList = data.lts;
+      const latest = official?.[0]?.version;
+      const lts = ltsList?.[0]?.version;
+      if (latest) {
+        await setVersion('Unity', 'current', latest);
+        logger.log(`✅ Unity (custom): current=${latest}`);
+      }
+      if (lts) {
+        await setVersion('Unity', 'lts', lts);
+        logger.log(`✅ Unity (custom): lts=${lts}`);
+      }
+    } catch (err) {
+      logger.error('❌ Erreur updateCustom [Unity]', err);
+    }
+  },
+  'Node.js': async (config, { http, setVersion, logger }) => {
+    const res = await firstValueFrom(http.get('https://nodejs.org/dist/index.json'));
+    const all = res.data;
+    const lts = all
+      .filter((r: any) => r.lts)
+      .sort((a: any, b: any) => semver.rcompare(a.version.replace('v', ''), b.version.replace('v', '')))[0];
+    const current = all
+      .filter((r: any) => !r.lts)
+      .sort((a: any, b: any) => semver.rcompare(a.version.replace('v', ''), b.version.replace('v', '')))[0];
+    if (current) await setVersion(config.nameInDb, 'current', current.version.replace(/^v/, ''), current.date);
+    if (lts) await setVersion(config.nameInDb, 'lts', lts.version.replace(/^v/, ''), lts.date);
+    logger.log(`✅ Node.js: current=${current?.version}, lts=${lts?.version}`);
+  },
+  nodejs: async (config, deps) => CUSTOM_UPDATERS["Node.js"](config, deps),
+  Go: async (config, { http, setVersion, logger, normalizeLabel }) => {
+    const res = await firstValueFrom(http.get(config.sourceUrl));
+    const stable = res.data.find((v: any) => v.stable);
+    if (stable?.version) {
+      const latest = stable.version.replace(/^go/, '');
+      await setVersion(config.nameInDb, 'current', normalizeLabel(config.nameInDb, latest));
+      logger.log(`✅ Go (custom): current=${latest}`);
+    } else {
+      logger.warn(`⚠️ Aucune version stable trouvée pour Go`);
+    }
+  },
+  Java: async (config, { http, setVersion, logger }) => {
+    const info = await firstValueFrom(http.get('https://api.adoptium.net/v3/info/available_releases'));
+    const available = info.data.available_releases as number[];
+    const ltsReleases = new Set(info.data.lts_releases as number[]);
+    const currentVersion = Math.max(...available);
+    const res = await firstValueFrom(
+      http.get(
+        `https://api.adoptium.net/v3/assets/feature_releases/${currentVersion}/ga?jvm_impl=hotspot&image_type=jdk&os=linux&page=0&page_size=1&sort_order=DESC`
+      )
+    );
+    const entry = res.data[0];
+    const sem = entry?.version_data?.semver ?? null;
+    const releaseDate = entry?.release_date ?? null;
+    if (sem) {
+      const cleanVersion = sem.split('+')[0];
+      await setVersion(config.nameInDb, 'current', cleanVersion, releaseDate);
+      if (ltsReleases.has(currentVersion)) {
+        await setVersion(config.nameInDb, 'lts', cleanVersion, releaseDate);
+      }
+      logger.log(`✅ Java (custom): current=${cleanVersion}${ltsReleases.has(currentVersion) ? `, lts=${cleanVersion}` : ''}`);
+    } else {
+      logger.warn(`⚠️ Java (custom): aucune version trouvée`);
+    }
+  },
+  Dart: async (config, { http, setVersion, logger }) => {
+    const res = await firstValueFrom(http.get(config.sourceUrl));
+    const version = res.data?.version;
+    if (version) {
+      await setVersion(config.nameInDb, 'current', version);
+      logger.log(`✅ Dart (custom): current=${version}`);
+    } else {
+      logger.warn(`⚠️ Impossible de récupérer la version de Dart`);
+    }
+  },
+  MongoDB: async (config, { http, setVersion, logger }) => {
+    const res = await firstValueFrom(http.get(config.sourceUrl, { responseType: 'text' as any }));
+    const match = res.data.match(/(\d+\.\d+\.\d+)\s+\(current\)/i);
+    if (match && match[1]) {
+      const version = match[1];
+      await setVersion(config.nameInDb, 'current', version);
+      logger.log(`✅ MongoDB (custom): current=${version}`);
+    } else {
+      logger.warn(`⚠️ MongoDB (custom): impossible de trouver la version sur la page`);
+    }
+  }
+};

--- a/src/langages/langage-sync.config.ts
+++ b/src/langages/langage-sync.config.ts
@@ -7,429 +7,98 @@ export interface LangageSyncConfig {
   ltsSupport?: boolean;
   ltsTagPrefix?: string;
   useTags?: boolean;
-  edition?: string; 
+  edition?: string;
   livingStandard?: boolean;
   standardSupport?: boolean;
 }
 
-export const SYNC_LANGAGES: LangageSyncConfig[] =  [
-  {
-    nameInDb: 'HTML',
-    sourceType: 'custom',
-    sourceUrl: 'html',
-    livingStandard: true
-  },
- /* {
-    nameInDb: 'CSS',
-    sourceType: 'custom',
-    sourceUrl: 'css',
-    livingStandard: true
-  },*/
-  {
-    nameInDb: 'JavaScript',
-    sourceType: 'github',
-    sourceUrl: 'tc39/ecma262',
-    useTags: true
-  },
-  {
-    nameInDb: 'ECMAScript',
-    sourceType: 'github',
-    sourceUrl: 'tc39/ecma262',
-    useTags: true
-  },
-  {
-  nameInDb: 'Angular',
+const npm = (nameInDb: string, pkg: string, opts: Partial<LangageSyncConfig> = {}): LangageSyncConfig => ({
+  nameInDb,
   sourceType: 'npm',
-  sourceUrl: '@angular/core',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'React',
-  sourceType: 'npm',
-  sourceUrl: 'react',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Vue.js',
-  sourceType: 'npm',
-  sourceUrl: 'vue',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'TypeScript',
-  sourceType: 'npm',
-  sourceUrl: 'typescript',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Node.js',
+  sourceUrl: pkg,
+  ...opts
+});
+
+const github = (nameInDb: string, repo: string, opts: Partial<LangageSyncConfig> = {}): LangageSyncConfig => ({
+  nameInDb,
+  sourceType: 'github',
+  sourceUrl: repo,
+  ...opts
+});
+
+const custom = (nameInDb: string, url: string, opts: Partial<LangageSyncConfig> = {}): LangageSyncConfig => ({
+  nameInDb,
   sourceType: 'custom',
-  sourceUrl: 'nodejs',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'NestJS',
-  sourceType: 'npm',
-  sourceUrl: '@nestjs/core',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Next.js',
-  sourceType: 'npm',
-  sourceUrl: 'next',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Nuxt',
-  sourceType: 'npm',
-  sourceUrl: 'nuxt',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Svelte',
-  sourceType: 'npm',
-  sourceUrl: 'svelte',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'SolidJS',
-  sourceType: 'npm',
-  sourceUrl: 'solid-js',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Qwik',
-  sourceType: 'npm',
-  sourceUrl: '@builder.io/qwik',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Electron',
-  sourceType: 'github',
-  sourceUrl: 'electron/electron',
-  ltsSupport: false,
-  useTags: true
-  },
-  {
-  nameInDb: 'Flutter',
-  sourceType: 'github',
-  sourceUrl: 'flutter/flutter',
-  ltsSupport: false,
-  useTags: true
-  },
-  {
-  nameInDb: 'Python',
-  sourceType: 'github',
-  sourceUrl: 'python/cpython',
-  ltsSupport: true,
-  useTags: true,
-  ltsTagPrefix: '3.10'
-  },
-  {
-  nameInDb: 'Go',
-  sourceType: 'custom',
-  sourceUrl: 'https://go.dev/dl/?mode=json',
-  ltsSupport: false,
-  },
-  {
-    nameInDb: 'Dart',
-    sourceType: 'custom',
-    sourceUrl: 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION',
-    ltsSupport: false,
-  },
-  {
-  nameInDb: 'Rust',
-  sourceType: 'github',
-  sourceUrl: 'rust-lang/rust',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Java',
-  sourceType: 'custom',
-  sourceUrl: 'https://api.adoptium.net/v3/assets/feature_releases?jvm_impl=hotspot&image_type=jdk&os=linux&page=0&page_size=100&project=jdk&sort_order=DESC',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'PHP',
-  sourceType: 'github',
-  sourceUrl: 'php/php-src',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Redis',
-  sourceType: 'github',
-  sourceUrl: 'redis/redis',
-  ltsSupport: false,
-  },
-  {
-    nameInDb: 'MongoDB',
-    sourceType: 'custom',
-    sourceUrl: 'https://www.mongodb.com/try/download/community',
-    ltsSupport: true,
-  },
-  {
-  nameInDb: 'PostgreSQL',
-  sourceType: 'custom',
-  sourceUrl: 'https://www.postgresql.org/docs/release/',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'MySQL',
-  sourceType: 'custom',
-  sourceUrl: 'https://dev.mysql.com/doc/relnotes/mysql/',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'Laravel',
-  sourceType: 'github',
-  sourceUrl: 'laravel/laravel',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Bootstrap',
-  sourceType: 'github',
-  sourceUrl: 'twbs/bootstrap',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Docker',
-  sourceType: 'github',
-  sourceUrl: 'moby/moby',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Kubernetes',
-  sourceType: 'github',
-  sourceUrl: 'kubernetes/kubernetes',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Ansible',
-  sourceType: 'github',
-  sourceUrl: 'ansible/ansible',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Swift',
-  sourceType: 'github',
-  sourceUrl: 'apple/swift',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Kotlin',
-  sourceType: 'github',
-  sourceUrl: 'JetBrains/kotlin',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Ruby',
-  sourceType: 'custom',
-  sourceUrl: 'ruby/ruby',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'C',
-  sourceType: 'custom',
-  sourceUrl: 'c',
-  standardSupport: true
-}
-, 
-  {
-  nameInDb: 'C#',
-  sourceType: 'github',
-  sourceUrl: 'dotnet/runtime',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'C++',
-  sourceType: 'github',
-  sourceUrl: 'cplusplus/draft',
-  ltsSupport: false,
-  useTags: true,
-  standardSupport: true,
-  },
-  {
-  nameInDb: 'Scala',
-  sourceType: 'github',
-  sourceUrl: 'scala/scala',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Symfony',
-  sourceType: 'github',
-  sourceUrl: 'symfony/symfony',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Astro',
-  sourceType: 'npm',
-  sourceUrl: 'astro',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Deno',
-  sourceType: 'github',
-  sourceUrl: 'denoland/deno',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Bun',
-  sourceType: 'github',
-  sourceUrl: 'oven-sh/bun',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Delphi',
-  sourceType: 'custom',
-  sourceUrl: 'delphi',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Lua',
-  sourceType: 'github',
-  sourceUrl: 'lua/lua',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'MATLAB',
-  sourceType: 'custom',
-  sourceUrl: 'matlab',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Julia',
-  sourceType: 'github',
-  sourceUrl: 'JuliaLang/julia',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Elixir',
-  sourceType: 'github',
-  sourceUrl: 'elixir-lang/elixir',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Zig',
-  sourceType: 'github',
-  sourceUrl: 'ziglang/zig',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Fortran',
-  sourceType: 'github',
-  sourceUrl: 'fortran-lang/stdlib',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'R',
-  sourceType: 'custom',
-  sourceUrl: 'wch/r-source',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'Perl',
-  sourceType: 'github',
-  sourceUrl: 'Perl/perl5',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'Unity',
-  sourceType: 'custom',
-  sourceUrl: 'unity',
-  ltsSupport: true,
-  },
-  {
-  nameInDb: 'Express.js',
-  sourceType: 'npm',
-  sourceUrl: 'express',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Spring',
-  sourceType: 'github',
-  sourceUrl: 'spring-projects/spring-framework',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Django',
-  sourceType: 'github',
-  sourceUrl: 'django/django',
-  ltsSupport: false,
-  ltsTagPrefix: '4.2',
-  useTags: true,
-  },
-  {
-  nameInDb: 'JSON',
-  sourceType: 'custom',
-  sourceUrl: 'json',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Bash',
-  sourceType: 'github',
-  sourceUrl: 'bminor/bash',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'Erlang',
-  sourceType: 'github',
-  sourceUrl: 'erlang/otp',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Nim',
-  sourceType: 'github',
-  sourceUrl: 'nim-lang/Nim',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'V',
-  sourceType: 'github',
-  sourceUrl: 'vlang/v',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'WebAssembly',
-  sourceType: 'github',
-  sourceUrl: 'WebAssembly/spec',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'SQL',
-  sourceType: 'custom',
-  sourceUrl: 'sql',
-  ltsSupport: false,
-  },
-  {
-  nameInDb: 'Haskell',
-  sourceType: 'github',
-  sourceUrl: 'ghc/ghc',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'Clojure',
-  sourceType: 'github',
-  sourceUrl: 'clojure/clojure',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'Flang',
-  sourceType: 'github',
-  sourceUrl: 'flang-compiler/flang',
-  ltsSupport: false,
-  useTags: true,
-  },
-  {
-  nameInDb: 'OCaml',
-  sourceType: 'github',
-  sourceUrl: 'ocaml/ocaml',
-  ltsSupport: false,
-  },
-  ];
+  sourceUrl: url,
+  ...opts
+});
+
+export const SYNC_LANGAGES: LangageSyncConfig[] = [
+  custom('HTML', 'html', { livingStandard: true }),
+  /* custom('CSS', 'css', { livingStandard: true }), */
+  github('JavaScript', 'tc39/ecma262', { useTags: true }),
+  github('ECMAScript', 'tc39/ecma262', { useTags: true }),
+  npm('Angular', '@angular/core', { ltsSupport: true }),
+  npm('React', 'react'),
+  npm('Vue.js', 'vue', { ltsSupport: true }),
+  npm('TypeScript', 'typescript'),
+  custom('Node.js', 'nodejs', { ltsSupport: true }),
+  npm('NestJS', '@nestjs/core'),
+  npm('Next.js', 'next'),
+  npm('Nuxt', 'nuxt'),
+  npm('Svelte', 'svelte'),
+  npm('SolidJS', 'solid-js'),
+  npm('Qwik', '@builder.io/qwik'),
+  github('Electron', 'electron/electron', { useTags: true }),
+  github('Flutter', 'flutter/flutter', { useTags: true }),
+  github('Python', 'python/cpython', { useTags: true, ltsSupport: true, ltsTagPrefix: '3.10' }),
+  custom('Go', 'https://go.dev/dl/?mode=json'),
+  custom('Dart', 'https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION'),
+  github('Rust', 'rust-lang/rust'),
+  custom('Java', 'https://api.adoptium.net/v3/assets/feature_releases?jvm_impl=hotspot&image_type=jdk&os=linux&page=0&page_size=100&project=jdk&sort_order=DESC', { ltsSupport: true }),
+  github('PHP', 'php/php-src'),
+  github('Redis', 'redis/redis'),
+  custom('MongoDB', 'https://www.mongodb.com/try/download/community', { ltsSupport: true }),
+  custom('PostgreSQL', 'https://www.postgresql.org/docs/release/', { ltsSupport: true }),
+  custom('MySQL', 'https://dev.mysql.com/doc/relnotes/mysql/', { ltsSupport: true }),
+  github('Laravel', 'laravel/laravel'),
+  github('Bootstrap', 'twbs/bootstrap'),
+  github('Docker', 'moby/moby'),
+  github('Kubernetes', 'kubernetes/kubernetes'),
+  github('Ansible', 'ansible/ansible'),
+  github('Swift', 'apple/swift'),
+  github('Kotlin', 'JetBrains/kotlin'),
+  custom('Ruby', 'ruby/ruby'),
+  custom('C', 'c', { standardSupport: true }),
+  github('C#', 'dotnet/runtime'),
+  github('C++', 'cplusplus/draft', { useTags: true, standardSupport: true }),
+  github('Scala', 'scala/scala'),
+  github('Symfony', 'symfony/symfony'),
+  npm('Astro', 'astro'),
+  github('Deno', 'denoland/deno'),
+  github('Bun', 'oven-sh/bun'),
+  custom('Delphi', 'delphi'),
+  github('Lua', 'lua/lua'),
+  custom('MATLAB', 'matlab'),
+  github('Julia', 'JuliaLang/julia'),
+  github('Elixir', 'elixir-lang/elixir'),
+  github('Zig', 'ziglang/zig'),
+  github('Fortran', 'fortran-lang/stdlib'),
+  custom('R', 'wch/r-source', { useTags: true }),
+  github('Perl', 'Perl/perl5', { useTags: true }),
+  custom('Unity', 'unity', { ltsSupport: true }),
+  npm('Express.js', 'express'),
+  github('Spring', 'spring-projects/spring-framework'),
+  github('Django', 'django/django', { useTags: true, ltsTagPrefix: '4.2' }),
+  custom('JSON', 'json'),
+  github('Bash', 'bminor/bash', { useTags: true }),
+  github('Erlang', 'erlang/otp'),
+  github('Nim', 'nim-lang/Nim', { useTags: true }),
+  github('V', 'vlang/v'),
+  github('WebAssembly', 'WebAssembly/spec', { useTags: true }),
+  custom('SQL', 'sql'),
+  github('Haskell', 'ghc/ghc', { useTags: true }),
+  github('Clojure', 'clojure/clojure', { useTags: true }),
+  github('Flang', 'flang-compiler/flang', { useTags: true }),
+  github('OCaml', 'ocaml/ocaml')
+];

--- a/src/langages/langage-update.service.ts
+++ b/src/langages/langage-update.service.ts
@@ -7,6 +7,7 @@ import { Langage } from '../langages/entities/langage.entity';
 import { SYNC_LANGAGES, LangageSyncConfig } from './langage-sync.config';
 import * as semver from 'semver';
 
+import { CUSTOM_UPDATERS, CustomUpdaterDeps } from "./custom-updaters";
 @Injectable()
 export class LangageUpdateService {
   private readonly logger = new Logger(LangageUpdateService.name);
@@ -253,160 +254,21 @@ export class LangageUpdateService {
     }
   }
 
+
   async updateCustom(config: LangageSyncConfig) {
     try {
-      if (config.nameInDb === 'Ruby') {
-        try {
-          const res = await firstValueFrom(
-            this.http.get('https://www.ruby-lang.org/en/downloads/', {
-              responseType: 'text' as any,
-            })
-          );
-
-          const match = res.data.match(/Stable releases:[^]*?Ruby\s+(\d+\.\d+\.\d+)/i);
-          if (match?.[1]) {
-            const version = match[1];
-            await this.setVersion('Ruby', 'current', version);
-            this.logger.log(`✅ Ruby (custom): current=${version}`);
-          } else {
-            this.logger.warn(`⚠️ Ruby (custom): impossible de détecter la version`);
-          }
-        } catch (error) {
-          this.logger.error(`❌ Erreur updateCustom [Ruby]:`, error);
-        }
+      const deps: CustomUpdaterDeps = {
+        http: this.http,
+        setVersion: this.setVersion.bind(this),
+        logger: this.logger,
+        normalizeLabel: this.normalizeLabel.bind(this)
+      };
+      const updater = CUSTOM_UPDATERS[config.nameInDb] || CUSTOM_UPDATERS[config.sourceUrl];
+      if (updater) {
+        await updater(config, deps);
         return;
       }
 
-      if (config.nameInDb === 'C') {
-        const res = await firstValueFrom(this.http.get(
-          'https://en.wikipedia.org/wiki/C_(programming_language)',
-          { responseType: 'text' as any }
-        ));
-        const wiki = res.data;
-
-        const found: Array<{ version: string; date?: string }> = [];
-        ['C23', 'C17', 'C11', 'C99'].forEach(ver => {
-          const regex = new RegExp(`${ver}.*?(?:ISO\\/IEC \\d+:\\d{4})`, 'i');
-          if (regex.test(wiki)) found.push({ version: ver });
-        });
-
-        if (found.length) {
-          for (const std of found) {
-            await this.setVersion('C', 'standard', std.version);
-          }
-          // Définir 'current' sur le premier standard détecté (le plus récent)
-          const current = found[0].version;
-          await this.setVersion('C', 'current', current);
-          this.logger.log(`📘 C (custom): standards=${found.map(f => f.version).join(', ')}, current=${current}`);
-        } else {
-          this.logger.warn('⚠️ C (custom): aucun standard détecté');
-        }
-        return;
-      }
-
-      if (config.nameInDb === 'MATLAB') {
-        const res = await firstValueFrom(this.http.get(
-          'https://www.mathworks.com/products/new_products/latest_features.html',
-          { responseType: 'text' as any }
-        ));
-
-        const match = res.data.match(/R(\d{4}[ab])/i); // ex: R2025a
-        if (match?.[1]) {
-          const raw = match[1]; // exemple : "2025a"
-          const numeric = raw.slice(0, 4) + (raw.endsWith('a') ? '.1' : '.2');
-          await this.setVersion('MATLAB', 'current', numeric);
-          this.logger.log(`✅ MATLAB (custom): current=${numeric}`);
-        } else {
-          this.logger.warn(`⚠️ MATLAB (custom): impossible de détecter la version`);
-        }
-      }
-
-      if (config.nameInDb === 'R') {
-        try {
-          const res = await firstValueFrom(
-            this.http.get('https://api.r-hub.io/rversions/r-release')
-          );
-          const latest = res.data?.version;
-          const date = res.data?.date;
-          if (latest) {
-            await this.setVersion('R', 'current', latest, date);
-            this.logger.log(`✅ R (custom via r-hub): current=${latest}`);
-          } else {
-            this.logger.warn(`⚠️ R (custom): version introuvable`);
-          }
-        } catch (err) {
-          this.logger.error(`❌ Erreur updateCustom [R]:`, err);
-        }
-        return;
-      }
-
-
-      if (config.nameInDb === 'Unity') {
-        try {
-          const res = await firstValueFrom(
-            this.http.get('https://public-cdn.cloud.unity3d.com/hub/prod/releases-linux.json')
-          );
-          const data = res.data;
-
-          const official = data.official;
-          const ltsList = data.lts;
-
-          const latest = official?.[0]?.version;
-          const lts = ltsList?.[0]?.version;
-
-          if (latest) {
-            await this.setVersion('Unity', 'current', latest);
-            this.logger.log(`✅ Unity (custom): current=${latest}`);
-          }
-
-          if (lts) {
-            await this.setVersion('Unity', 'lts', lts);
-            this.logger.log(`✅ Unity (custom): lts=${lts}`);
-          }
-
-        } catch (err) {
-          this.logger.error('❌ Erreur updateCustom [Unity]', err);
-        }
-        return;
-      }
-
-
-
-
-
-
-
-
-
-
-      if (config.sourceUrl === 'nodejs') {
-        const res = await firstValueFrom(this.http.get('https://nodejs.org/dist/index.json'));
-        const all = res.data;
-
-        const lts = all.filter((r: any) => r.lts)
-          .sort((a, b) => semver.rcompare(a.version.replace('v', ''), b.version.replace('v', '')))[0];
-
-        const current = all.filter((r: any) => !r.lts)
-          .sort((a, b) => semver.rcompare(a.version.replace('v', ''), b.version.replace('v', '')))[0];
-
-        if (current) await this.setVersion(config.nameInDb, 'current', current.version.replace(/^v/, ''), current.date);
-        if (lts) await this.setVersion(config.nameInDb, 'lts', lts.version.replace(/^v/, ''), lts.date);
-
-        this.logger.log(`✅ Node.js: current=${current?.version}, lts=${lts?.version}`);
-      }
-
-      if (config.sourceUrl.includes('go.dev')) {
-        const res = await firstValueFrom(this.http.get(config.sourceUrl));
-        const stable = res.data.find((v: any) => v.stable);
-
-        if (stable?.version) {
-          const latest = stable.version.replace(/^go/, '');
-          await this.setVersion(config.nameInDb, 'current', this.normalizeLabel(config.nameInDb, latest));
-          this.logger.log(`✅ Go (custom): current=${latest}`);
-        } else {
-          this.logger.warn(`⚠️ Aucune version stable trouvée pour Go`);
-        }
-      }
       if (config.livingStandard) {
         await this.setVersion(config.nameInDb, 'livingStandard', 'Living Standard');
         this.logger.log(`✅ ${config.nameInDb} (custom): livingStandard`);
@@ -417,76 +279,10 @@ export class LangageUpdateService {
         this.logger.log(`✅ ${config.nameInDb} (custom): edition=${config.edition}`);
       }
 
-      if (config.nameInDb === 'Java') {
-        const info = await firstValueFrom(this.http.get('https://api.adoptium.net/v3/info/available_releases'));
-        const available = info.data.available_releases as number[];
-        const ltsReleases = new Set(info.data.lts_releases as number[]);
-        const currentVersion = Math.max(...available);
-
-        const res = await firstValueFrom(this.http.get(
-          `https://api.adoptium.net/v3/assets/feature_releases/${currentVersion}/ga?jvm_impl=hotspot&image_type=jdk&os=linux&page=0&page_size=1&sort_order=DESC`
-        ));
-
-        const entry = res.data[0];
-        const semver = entry?.version_data?.semver ?? null;
-        const releaseDate = entry?.release_date ?? null;
-
-        if (semver) {
-          const cleanVersion = semver.split('+')[0]; // remove build metadata
-          await this.setVersion(config.nameInDb, 'current', cleanVersion, releaseDate);
-
-          if (ltsReleases.has(currentVersion)) {
-            await this.setVersion(config.nameInDb, 'lts', cleanVersion, releaseDate);
-          }
-
-          this.logger.log(`✅ Java (custom): current=${cleanVersion}${ltsReleases.has(currentVersion) ? `, lts=${cleanVersion}` : ''}`);
-        } else {
-          this.logger.warn(`⚠️ Java (custom): aucune version trouvée`);
-        }
-      }
-
-      if (config.sourceUrl.includes('dart-archive')) {
-        const res = await firstValueFrom(this.http.get(config.sourceUrl));
-        const version = res.data?.version;
-
-        if (version) {
-          await this.setVersion(config.nameInDb, 'current', version);
-          this.logger.log(`✅ Dart (custom): current=${version}`);
-        } else {
-          this.logger.warn(`⚠️ Impossible de récupérer la version de Dart`);
-        }
-
-        return;
-      }
-
-      if (config.nameInDb === 'MongoDB') {
-        const res = await firstValueFrom(this.http.get(config.sourceUrl, { responseType: 'text' as any }));
-        const match = res.data.match(/(\d+\.\d+\.\d+)\s+\(current\)/i);
-        if (match && match[1]) {
-          const version = match[1];
-          await this.setVersion(config.nameInDb, 'current', version);
-          this.logger.log(`✅ MongoDB (custom): current=${version}`);
-        } else {
-          this.logger.warn(`⚠️ MongoDB (custom): impossible de trouver la version sur la page`);
-        }
-        return;
-      }
-
-
-
-
-
-
-
-
-
-
-
-
-
     } catch (error) {
       this.logger.error(`❌ Erreur updateCustom [${config.nameInDb}]:`, error);
       throw error;
     }
   }
+
 }


### PR DESCRIPTION
## Summary
- extract custom update routines to `custom-updaters.ts`
- use helper builders in `langage-sync.config.ts`
- simplify `LangageUpdateService.updateCustom`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686830d28488832d9c7865ee3f5d9b39